### PR TITLE
allocate buffers depending on row size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ checksum = "8e9a4248ee77a186e15dea766856c229efdf0276e185bb0f2fc7104dc11db018"
 
 [[package]]
 name = "odbc2parquet"
-version = "0.5.11"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "0.5.11"
+version = "0.6.0"
 authors = ["Markus Klein <markus-klein@live.de>"]
 edition = "2018"
 repository = "https://github.com/pacman82/odbc2parquet"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## 0.5.11 (next version)
+## 0.6.0 (next version)
 
 * Requires at least Rust 1.51.0 to build.
 * Command line parameters `user` and `password` will no longer be ignored then passed together with a connection string. Instead their values will be appended as `UID` and `PWD` attributes at the end.
+* `--batch-size` command line flag has been renamed to `batch-size-row`.
+* Introduced `--batch-size-mib` command line flag to limit batch size based on memory usage
+* Default batch size is adapted so buffer allocation requires 2 GiB on 64 Bit platforms and 1 GiB on 32 Bit Platforms. 
+* Fix: There is now an error message produced if the resulting parquet file would not contain any columns.
 
 ## 0.5.10
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,15 @@ pub struct QueryOpt {
     connect_opts: ConnectOpts,
     /// Size of a single batch in rows. The content of the data source is written into the output
     /// parquet files in batches. This way the content does never need to be materialized completely
-    /// in memory at once.
-    #[structopt(long, default_value = "100000")]
-    batch_size: u32,
+    /// in memory at once. Incompatible with `batch-size-mib`.
+    #[structopt(long)]
+    batch_size_row: Option<u32>,
+    /// Limits the size of a single batch. It does so by calculating the amount of memory each row
+    /// requires in the allocated buffers and then limits the maximum number of rows so that the
+    /// maximum buffer size comes as close as possbile, but does not exceed the specified amount.
+    /// Default is 2 GiB on 64 Bit platforms and 1 GiB on 32 Bit Platforms.
+    #[structopt(long)]
+    batch_size_mib: Option<u32>,
     /// Maximum number of batches in a single output parquet file. If this option is omitted or 0 a
     /// single output file is produces. Otherwise each output file is closed after the maximum
     /// number of batches have been written and a new one with the suffix `_n` is started. There n

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -278,7 +278,7 @@ fn split_files() {
             out_str,
             "--connection-string",
             MSSQL,
-            "--batch-size",
+            "--batch-size-row",
             "1",
             "--batches-per-file",
             "1",
@@ -350,6 +350,46 @@ fn varbinary_column() {
     // `cargo install parquet`.
     let mut cmd = Command::new("parquet-read");
     cmd.arg(out_str).assert().success().stdout(eq(expected));
+}
+
+#[test]
+fn query_varchar_max() {
+    let conn = ENV.connect_with_connection_string(MSSQL).unwrap();
+    let table_name = "QueryVarcharMax";
+
+    setup_empty_table(&conn, table_name, &["VARCHAR(MAX)"]).unwrap();
+    conn.execute(
+        &format!(
+            "INSERT INTO {} (a) Values ('Hello'), ('World');",
+            table_name
+        ),
+        (),
+    )
+    .unwrap();
+
+    // A temporary directory, to be removed at the end of the test.
+    let out_dir = tempdir().unwrap();
+    // The name of the output parquet file we are going to write. Since it is in a temporary
+    // directory it will not outlive the end of the test.
+    let out_path = out_dir.path().join("out.par");
+    // We need to pass the output path as a string argument.
+    let out_str = out_path.to_str().expect("Temporary file path must be utf8");
+
+    let query = format!("SELECT a FROM {};", table_name);
+
+    // VARCHAR(max) has size 0. => Column is ignored and file would be empty and schemaless
+    Command::cargo_bin("odbc2parquet")
+        .unwrap()
+        .args(&[
+            "-vvvv",
+            "query",
+            "--connection-string",
+            MSSQL,
+            out_str,
+            &query,
+        ])
+        .assert()
+        .failure();
 }
 
 #[test]


### PR DESCRIPTION
Partly addresses issue #43. New default buffer size is 2 GiB on 64 Bit platforms and 1 GiB on 32 Bit platforms.