### PR TITLE
introduce column compression default argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ checksum = "8e9a4248ee77a186e15dea766856c229efdf0276e185bb0f2fc7104dc11db018"
 
 [[package]]
 name = "odbc2parquet"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Markus Klein <markus-klein@live.de>"]
 edition = "2018"
 repository = "https://github.com/pacman82/odbc2parquet"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1
+
+* Introduced `--column-compression-default` in order to allow users to specify column compression.
+* Default column compression is now `gzip`.
+
 ## 0.6.0
 
 * Requires at least Rust 1.51.0 to build.

--- a/src/enum_args.rs
+++ b/src/enum_args.rs
@@ -1,3 +1,5 @@
+use anyhow::{bail, Error};
+use parquet::basic::Compression;
 use structopt::clap::arg_enum;
 
 arg_enum! {
@@ -24,4 +26,28 @@ impl EncodingArgument {
             EncodingArgument::Auto => false,
         }
     }
+}
+
+pub const COMPRESSION_VARIANTS: &[&str] = &[
+    "uncompressed",
+    "gzip",
+    "lz4",
+    "lz0",
+    "zstd",
+    "snappy",
+    "brotli",
+];
+
+pub fn compression_from_str(source: &str) -> Result<Compression, Error> {
+    let compression = match source {
+        "uncompressed" => Compression::UNCOMPRESSED,
+        "gzip" => Compression::GZIP,
+        "lz4" => Compression::LZ4,
+        "lz0" => Compression::LZO,
+        "zstd" => Compression::ZSTD,
+        "snappy" => Compression::SNAPPY,
+        "brotli" => Compression::BROTLI,
+        _ => bail!("Sorry, I do not know this compression identifier."),
+    };
+    Ok(compression)
 }

--- a/src/enum_args.rs
+++ b/src/enum_args.rs
@@ -28,6 +28,7 @@ impl EncodingArgument {
     }
 }
 
+/// Used to display a number of valid values for the compression argumet to the user.
 pub const COMPRESSION_VARIANTS: &[&str] = &[
     "uncompressed",
     "gzip",
@@ -38,6 +39,7 @@ pub const COMPRESSION_VARIANTS: &[&str] = &[
     "brotli",
 ];
 
+/// Used to parse the compression from the command line argument.
 pub fn compression_from_str(source: &str) -> Result<Compression, Error> {
     let compression = match source {
         "uncompressed" => Compression::UNCOMPRESSED,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
-mod encoding;
+mod enum_args;
 mod insert;
 mod parquet_buffer;
 mod query;
 
-use crate::encoding::EncodingArgument;
+use crate::enum_args::{compression_from_str, EncodingArgument, COMPRESSION_VARIANTS};
 use anyhow::{bail, Error};
 use odbc_api::{escape_attribute_value, Connection, Environment};
+use parquet::basic::Compression;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -82,6 +83,14 @@ pub struct QueryOpt {
     /// `out_2.par`, ...
     #[structopt(long, default_value = "0")]
     batches_per_file: u32,
+    /// Default compression used by the parquet file writer.
+    #[structopt(
+        long,
+        possible_values=COMPRESSION_VARIANTS,
+        default_value="gzip",
+        parse(try_from_str=compression_from_str)
+    )]
+    column_compression_default: Compression,
     /// Encoding used for character data requested from the data source.
     ///
     /// `Utf16`: The tool will use 16Bit characters for requesting text from the data source,

--- a/src/parquet_buffer.rs
+++ b/src/parquet_buffer.rs
@@ -366,7 +366,6 @@ mod test {
 
     use super::ParquetBuffer;
 
-    
     #[test]
     #[cfg(target_pointer_width = "64")] // Memory usage is platform dependent
     fn memory_usage() {


### PR DESCRIPTION
See issue #51 . Introduces `--column-compression-default` argument for `query` subcommand.