### PR TITLE
ignore zero sized columns, then utf16 mode is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "74579a55ae5f527c655dc02cc1992677adb3c3e59bbeddccca800dfff7fe026f"
 
 [[package]]
 name = "odbc2parquet"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Markus Klein <markus-klein@live.de>"]
 edition = "2018"
 repository = "https://github.com/pacman82/odbc2parquet"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.3
+
+* Fix: Columns for which the driver reported size zero were not ignored then UTF-16 encoding had been enabled. This is the default setting for Windows. These columns are now complete missing from the output file, instead of the column being present with all values being NULL or empty strings.
+
 ## 0.6.2
 
 * Introduced support for connecting via GUI on windows platforms via `--prompt` flag.

--- a/src/query.rs
+++ b/src/query.rs
@@ -511,7 +511,10 @@ fn make_schema(
             Nullability::NoNulls => Repetition::REQUIRED,
         };
 
-        if matches!(buffer_kind, BufferKind::Text { max_str_len: 0 }) {
+        if matches!(
+            buffer_kind,
+            BufferKind::Text { max_str_len: 0 } | BufferKind::WText { max_str_len: 0 }
+        ) {
             warn!(
                 "Ignoring column '{}' with index {}. Driver reported a display length of 0. \
               This can happen for types without a fixed size limit. If you feel this should be \


### PR DESCRIPTION
See issue #59 .