### PR TITLE
Added new option --prefer-int-over-decimal that uses INT as Converted…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,12 @@ pub struct QueryOpt {
     /// can make queries work which did not before, because Oracle does not support 64 Bit integers.
     #[clap(long)]
     driver_does_not_support_64bit_integers: bool,
+    /// When writing to Parquet file prefer using Int over Decimal as the Converted type
+    /// when scale is 0.
+    /// Decimal(1-9, 0) -> INT_32,
+    /// Decimal(10-19, 0) -> INT_64
+    #[clap(long)]
+    prefer_int_over_decimal: bool,
     /// In case fetch results gets split into multiple files a suffix with a number will be appended
     /// to each file name. Default suffix length is 2 leading to suffixes like e.g. `_03`. In case
     /// you would expect thousands of files in your output you may want to set this to say `4` so

--- a/src/query.rs
+++ b/src/query.rs
@@ -46,6 +46,7 @@ pub fn query(environment: &Environment, opt: QueryOpt) -> Result<(), Error> {
         column_compression_default,
         parquet_column_encoding,
         driver_does_not_support_64bit_integers,
+        prefer_int_over_decimal,
         suffix_length,
     } = opt;
 
@@ -73,6 +74,7 @@ pub fn query(environment: &Environment, opt: QueryOpt) -> Result<(), Error> {
         use_utf16: encoding.use_utf16(),
         prefer_varbinary,
         driver_does_support_i64: !driver_does_not_support_64bit_integers,
+        prefer_int_over_decimal: prefer_int_over_decimal,
     };
 
     if let Some(cursor) = odbc_conn.execute(&query, params.as_slice())? {

--- a/src/query/strategy.rs
+++ b/src/query/strategy.rs
@@ -22,7 +22,7 @@ use crate::{
         binary::Binary,
         boolean::Boolean,
         date::Date,
-        decimal::decmial_fetch_strategy,
+        decimal::decimal_fetch_strategy,
         identical::{fetch_identical, fetch_identical_with_converted_type},
         text::{Utf16ToUtf8, Utf8},
         timestamp::TimestampToInt,
@@ -54,6 +54,7 @@ pub struct MappingOptions<'a> {
     pub use_utf16: bool,
     pub prefer_varbinary: bool,
     pub driver_does_support_i64: bool,
+    pub prefer_int_over_decimal: bool,
 }
 
 pub fn strategy_from_column_description(
@@ -68,6 +69,7 @@ pub fn strategy_from_column_description(
         use_utf16,
         prefer_varbinary,
         driver_does_support_i64,
+        prefer_int_over_decimal,
     } = mapping_options;
 
     // Convert ODBC nullability to Parquet repetition. If the ODBC driver can not tell wether a
@@ -94,11 +96,12 @@ pub fn strategy_from_column_description(
         }
         DataType::Date => Box::new(Date::new(repetition)),
         DataType::Numeric { scale, precision } | DataType::Decimal { scale, precision } => {
-            decmial_fetch_strategy(
+            decimal_fetch_strategy(
                 is_optional,
                 scale as i32,
                 precision.try_into().unwrap(),
                 driver_does_support_i64,
+                prefer_int_over_decimal,
             )
         }
         DataType::Timestamp { precision } => Box::new(TimestampToInt::new(


### PR DESCRIPTION
odbc2parquet is a great program! I have had no problems with it. 

This is just a small extra feature that I and maybe some others need. Maybe you want to add it to your code.  

Added new option --prefer-int-over-decimal that uses INT as Converted type when Decimal scale is 0.

Background:
At the moment Polars, https://www.pola.rs/, doesn't support decimal. 
In the database I am reading from they use Decimal with scale set to 0, i.e. a it's just an integer.
For Decimal with scale=0 it's possible to set the Converted type to INT_32 or INT_64, depending on the precision,
and then Polars can read the data from the parquet file.

Tested by reading data from a SQL server database with the new option. I was able to read the generated parquet file using NuShell that uses Polars for creating dataframes.  

OBS I am not a Rust programmer and doesn't have deep knowledge of parquet format. 