### PR TITLE
Docker support (5.77MB uncompressed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:alpine AS builder
+#FROM rustlang/rust:nightly-alpine AS builder
+
+RUN apk add --no-cache musl-dev unixodbc-static
+
+WORKDIR /src/odbc2parquet
+COPY . .
+RUN cargo build --release
+
+FROM scratch AS runner
+
+COPY --from=builder /src/odbc2parquet/target/release/odbc2parquet /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/odbc2parquet"]


### PR DESCRIPTION
Closes #600 

Depending on what you want can switch from `scratch` to something with a few drivers installed by default for both debian and alpine bases.