### PR TITLE
Build release assets for Ubuntu ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Build
         run: |
           cargo build --release
-          Compress-Archive -LiteralPath target/release/odbc2parquet.exe -DestinationPath odbc2parquet-win64.zip
+          Compress-Archive -LiteralPath target/release/odbc2parquet.exe -DestinationPath odbc2parquet-win-x64.zip
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: odbc2parquet-win64.zip
-          asset_name: odbc2parquet-win64.zip
+          file: odbc2parquet-win-x64.zip
+          asset_name: odbc2parquet-win-x64.zip
           tag: ${{ github.ref }}
 
   release_win32:
@@ -46,13 +46,13 @@ jobs:
       - name: Build
         run: |
           cargo build --release
-          Compress-Archive -LiteralPath target/release/odbc2parquet.exe -DestinationPath odbc2parquet-win32.zip
+          Compress-Archive -LiteralPath target/release/odbc2parquet.exe -DestinationPath odbc2parquet-win-x86.zip
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: odbc2parquet-win32.zip
-          asset_name: odbc2parquet-win32.zip
+          file: odbc2parquet-win-x86.zip
+          asset_name: odbc2parquet-win-x86.zip
           tag: ${{ github.ref }}
 
   release_osx:
@@ -75,13 +75,13 @@ jobs:
         run: |
           cargo build --release
           gzip --force target/release/odbc2parquet
-          mv target/release/odbc2parquet.gz odbc2parquet-osx.gz
+          mv target/release/odbc2parquet.gz odbc2parquet-macos-x64.gz
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: odbc2parquet-osx.gz
-          asset_name: odbc2parquet-osx.gz
+          file: odbc2parquet-macos-x64.gz
+          asset_name: odbc2parquet-macos-x64.gz
           tag: ${{ github.ref }}
 
       - name: Publish to cargo
@@ -102,17 +102,17 @@ jobs:
         run: |
           cargo build --release
           gzip --force target/release/odbc2parquet
-          mv target/release/odbc2parquet.gz odbc2parquet-x86_64-ubuntu.gz
+          mv target/release/odbc2parquet.gz odbc2parquet-ubuntu-x64.gz
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: odbc2parquet-x86_64-ubuntu.gz
-          asset_name: odbc2parquet-x86_64-ubuntu.gz
+          file: odbc2parquet-ubuntu-x64.gz
+          asset_name: odbc2parquet-ubuntu-x64.gz
           tag: ${{ github.ref }}
 
   release_m1:
-    name: Build and release macOS M1
+    name: Build and release macOS ARM64
     # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
     runs-on: macos-latest # ARM-based macOS runner (Apple Silicon)
 
@@ -136,13 +136,13 @@ jobs:
         run: |
           cargo build --release
           gzip --force target/release/odbc2parquet
-          mv target/release/odbc2parquet.gz odbc2parquet-macos-m1.gz
+          mv target/release/odbc2parquet.gz odbc2parquet-macos-arm64.gz
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: odbc2parquet-macos-m1.gz
-          asset_name: odbc2parquet-macos-m1.gz
+          file: odbc2parquet-macos-arm64.gz
+          asset_name: odbc2parquet-macos-arm64.gz
           tag: ${{ github.ref }}
 
   release_arm_ubuntu:
@@ -168,11 +168,11 @@ jobs:
         run: |
           cross build --release --target aarch64-unknown-linux-gnu
           gzip --force target/aarch64-unknown-linux-gnu/release/odbc2parquet
-          mv target/aarch64-unknown-linux-gnu/release/odbc2parquet.gz odbc2parquet-arm64-ubuntu.gz
+          mv target/aarch64-unknown-linux-gnu/release/odbc2parquet.gz odbc2parquet-ubuntu-arm64.gz
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: odbc2parquet-arm64-ubuntu.gz
-          asset_name: odbc2parquet-arm64-ubuntu.gz
+          file: odbc2parquet-arm64-ubuntu-arm64.gz
+          asset_name: odbc2parquet-arm64-ubuntu-arm64.gz
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,8 +148,10 @@ jobs:
           default: true
           override: true
 
-      - name: Install cross for cross-compilation
-        run: cargo install cross
+      - name: Install Unix ODBC
+        run: |
+          brew install unixodbc
+          sudo ln -s /opt/homebrew/lib ~/lib
 
       - name: Cross-build for Ubuntu ARM (aarch64)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,18 +140,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install latest rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+          default: true
+          override: true
+
       - name: Install cross for cross-compilation
         run: cargo install cross
 
       - name: Cross-build for Ubuntu ARM (aarch64)
         run: |
-          cross build --release --target aarch64-unknown-linux-gnu
+          cargo build --release --target aarch64-unknown-linux-gnu
           gzip --force target/aarch64-unknown-linux-gnu/release/odbc2parquet
           mv target/aarch64-unknown-linux-gnu/release/odbc2parquet.gz odbc2parquet-ubuntu-arm64.gz
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: odbc2parquet-arm64-ubuntu-arm64.gz
-          asset_name: odbc2parquet-arm64-ubuntu-arm64.gz
+          file: odbc2parquet-ubuntu-arm64.gz
+          asset_name: odbc2parquet-ubuntu-arm64.gz
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           asset_name: odbc2parquet-win-x86.zip
           tag: ${{ github.ref }}
 
-  release_osx:
+  release_macos_intel:
     name: Build and release macOS Intel
     # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
     runs-on: macos-13 # Intel-based macOS runner
@@ -83,7 +83,7 @@ jobs:
         run: |
           cargo publish --token "${CARGO_TOKEN}"
 
-  ubuntu:
+  release_ubuntu_x64:
     name: Build and release Ubuntu x86_64
     runs-on: ubuntu-latest
 
@@ -104,7 +104,7 @@ jobs:
           asset_name: odbc2parquet-ubuntu-x64.gz
           tag: ${{ github.ref }}
 
-  release_m1:
+  release_macos_arm64:
     name: Build and release macOS ARM64
     # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
     runs-on: macos-latest # ARM-based macOS runner (Apple Silicon)
@@ -131,7 +131,7 @@ jobs:
           asset_name: odbc2parquet-macos-arm64.gz
           tag: ${{ github.ref }}
 
-  release_arm_ubuntu:
+  release_ubuntu_arm64:
     name: Build and release Ubuntu ARM64
     # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
     runs-on: macos-latest # ARM-based macOS runner to cross-compile for Ubuntu ARM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release_win64:
-    name: Build and release Windows 64Bit
+    name: Build and release Windows 64-bit
     runs-on: windows-latest
 
     steps:
@@ -28,7 +28,7 @@ jobs:
           tag: ${{ github.ref }}
 
   release_win32:
-    name: Build and release Windows 32Bit
+    name: Build and release Windows 32-bit
     runs-on: windows-latest
 
     steps:
@@ -55,9 +55,10 @@ jobs:
           asset_name: odbc2parquet-win32.zip
           tag: ${{ github.ref }}
 
-  release_os-x:
-    name: Build and release OS-X
-    runs-on: macos-latest
+  release_osx:
+    name: Build and release macOS Intel
+    # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+    runs-on: macos-13 # Intel-based macOS runner
 
     steps:
       - name: Checkout
@@ -90,7 +91,7 @@ jobs:
           cargo publish --token "${CARGO_TOKEN}"
 
   ubuntu:
-    name: Build and release for Ubuntu
+    name: Build and release Ubuntu x86_64
     runs-on: ubuntu-latest
 
     steps:
@@ -111,8 +112,9 @@ jobs:
           tag: ${{ github.ref }}
 
   release_m1:
-    name: Build and release macos M1
-    runs-on: flyci-macos-14-m1
+    name: Build and release macOS M1
+    # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+    runs-on: macos-latest # ARM-based macOS runner (Apple Silicon)
 
     steps:
       - name: Checkout
@@ -144,8 +146,9 @@ jobs:
           tag: ${{ github.ref }}
 
   release_arm_ubuntu:
-    name: Build and release Ubuntu ARM (aarch64)
-    runs-on: macos-latest # Use MacOS runner with ARM architecture
+    name: Build and release Ubuntu ARM64
+    # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+    runs-on: macos-latest # ARM-based macOS runner to cross-compile for Ubuntu ARM
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           file: odbc2parquet-win64.zip
           asset_name: odbc2parquet-win64.zip
           tag: ${{ github.ref }}
-  
+
   release_win32:
     name: Build and release Windows 32Bit
     runs-on: windows-latest
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install latests rust toolchain
+      - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -63,7 +63,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install latests rust toolchain
+      - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -135,4 +135,35 @@ jobs:
         with:
           file: target/release/odbc2parquet
           asset_name: odbc2parquet-macos-m1
+          tag: ${{ github.ref }}
+
+  release_arm_ubuntu:
+    name: Build and release Ubuntu ARM (aarch64)
+    runs-on: macos-latest # Use MacOS runner with ARM architecture
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install latest rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          override: true
+
+      - name: Install cross for cross-compilation
+        run: cargo install cross
+
+      - name: Cross-build for Ubuntu ARM (aarch64)
+        run: |
+          cross build --release --target aarch64-unknown-linux-gnu
+          gzip --force target/aarch64-unknown-linux-gnu/release/odbc2parquet
+          mv target/aarch64-unknown-linux-gnu/release/odbc2parquet.gz odbc2parquet-arm64-ubuntu.gz
+
+      - name: Github Upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: odbc2parquet-arm64-ubuntu.gz
+          asset_name: odbc2parquet-arm64-ubuntu.gz
           tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,16 @@ jobs:
           override: true
 
       - name: Build
-        run: cargo build --release
+        run: |
+          cargo build --release
+          gzip --force target/release/odbc2parquet
+          mv target/release/odbc2parquet.gz odbc2parquet-osx.gz
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: target/release/odbc2parquet
-          asset_name: odbc2parquet-osx
+          file: odbc2parquet-osx.gz
+          asset_name: odbc2parquet-osx.gz
           tag: ${{ github.ref }}
 
       - name: Publish to cargo
@@ -128,13 +131,16 @@ jobs:
           sudo ln -s /opt/homebrew/lib ~/lib
 
       - name: Build
-        run: cargo build --release
+        run: |
+          cargo build --release
+          gzip --force target/release/odbc2parquet
+          mv target/release/odbc2parquet.gz odbc2parquet-macos-m1.gz
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
         with:
-          file: target/release/odbc2parquet
-          asset_name: odbc2parquet-macos-m1
+          file: odbc2parquet-macos-m1.gz
+          asset_name: odbc2parquet-macos-m1.gz
           tag: ${{ github.ref }}
 
   release_arm_ubuntu:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
-
       - name: Build
         run: |
           cargo build --release
@@ -120,13 +113,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
-
       - name: Install Unix ODBC
         run: |
           brew install unixodbc
@@ -153,13 +139,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
 
       - name: Install cross for cross-compilation
         run: cargo install cross


### PR DESCRIPTION
### **Add Compression for Release Artifacts and Ubuntu ARM Cross-Compilation**

#### **Summary:**
This pull request addresses https://github.com/pacman82/odbc2parquet/issues/491 by adding support for cross-compiling Ubuntu ARM (aarch64) binaries and compressing all release artifacts for efficient storage and faster downloads.

---

### **Key Changes:**
1. **Ubuntu ARM Cross-Compilation:**
   - A new job, `release_ubuntu_arm64`, cross-compiles an Ubuntu ARM binary using the appropriate Rust toolchain on a macOS ARM runner. The binary is compressed and uploaded as `odbc2parquet-ubuntu-arm64.gz`.

2. **Compression of All Release Artifacts:**
   - All platform-specific binaries are now compressed before upload:
     - **Windows** binaries (`.exe`) are packaged as `.zip` files using `Compress-Archive`.
     - **macOS** and **Linux** binaries are compressed as `.gz` files using `gzip`.

---

### **Artifacts Summary:**
- **Windows 64-bit:** `odbc2parquet-win-x64.zip`
- **Windows 32-bit:** `odbc2parquet-win-x86.zip`
- **macOS (Intel):** `odbc2parquet-macos-x64.gz`
- **macOS (ARM):** `odbc2parquet-macos-arm64.gz`
- **Ubuntu (x86_64):** `odbc2parquet-ubuntu-x64.gz`
- **Ubuntu (ARM):** `odbc2parquet-ubuntu-arm64.gz`

---

### **Why These Changes?**
- **Supports ARM Platforms:** Adds cross-compilation for Ubuntu ARM (aarch64), addressing https://github.com/pacman82/odbc2parquet/issues/491.
- **Improved Efficiency:** Compressing binaries reduces artifact size for faster downloads and better storage utilization.