### PR TITLE
Properly cross-build for Windows x86 and Ubuntu ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,17 +36,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           target: i686-pc-windows-msvc
-          default: true
-          override: true
 
       - name: Build
         run: |
-          cargo build --release
-          Compress-Archive -LiteralPath target/release/odbc2parquet.exe -DestinationPath odbc2parquet-win-x86.zip
+          cargo build --release --target i686-pc-windows-msvc
+          Compress-Archive -LiteralPath target/i686-pc-windows-msvc/release/odbc2parquet.exe -DestinationPath odbc2parquet-win-x86.zip
 
       - name: Github Upload
         uses: svenstaro/upload-release-action@v2
@@ -91,27 +89,6 @@ jobs:
           asset_name: odbc2parquet-macos-x86_64.gz
           tag: ${{ github.ref }}
 
-  release_ubuntu_x64:
-    name: Build and release Ubuntu x86_64
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Build
-        run: |
-          cargo build --release
-          gzip --force target/release/odbc2parquet
-          mv target/release/odbc2parquet.gz odbc2parquet-ubuntu-x86_64.gz
-
-      - name: Github Upload
-        uses: svenstaro/upload-release-action@v2
-        with:
-          file: odbc2parquet-ubuntu-x86_64.gz
-          asset_name: odbc2parquet-ubuntu-x86_64.gz
-          tag: ${{ github.ref }}
-
   release_macos_arm64:
     name: Build and release macOS ARM64
     # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
@@ -139,39 +116,53 @@ jobs:
           asset_name: odbc2parquet-macos-arm64.gz
           tag: ${{ github.ref }}
 
-  # Doesn't work yet. Needs package `aarch64-linux-gnu-gcc`
-  #
-  # release_ubuntu_arm64:
-  #   name: Build and release Ubuntu ARM64
-  #   # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
-  #   runs-on: macos-latest # ARM-based macOS runner to cross-compile for Ubuntu ARM
+  release_ubuntu_x64:
+    name: Build and release Ubuntu x86_64
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Install latest rust toolchain
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         target: aarch64-unknown-linux-gnu
-  #         default: true
-  #         override: true
+      - name: Build
+        run: |
+          cargo build --release
+          gzip --force target/release/odbc2parquet
+          mv target/release/odbc2parquet.gz odbc2parquet-ubuntu-x86_64.gz
 
-  #     - name: Install Unix ODBC
-  #       run: |
-  #         brew install unixodbc
-  #         sudo ln -s /opt/homebrew/lib ~/lib
+      - name: Github Upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: odbc2parquet-ubuntu-x86_64.gz
+          asset_name: odbc2parquet-ubuntu-x86_64.gz
+          tag: ${{ github.ref }}
 
-  #     - name: Cross-build for Ubuntu ARM (aarch64)
-  #       run: |
-  #         cargo build --release --target aarch64-unknown-linux-gnu
-  #         gzip --force target/aarch64-unknown-linux-gnu/release/odbc2parquet
-  #         mv target/aarch64-unknown-linux-gnu/release/odbc2parquet.gz odbc2parquet-ubuntu-arm64.gz
+  release_ubuntu_arm64:
+    name: Build and release Ubuntu ARM64
+    runs-on: ubuntu-latest
 
-  #     - name: Github Upload
-  #       uses: svenstaro/upload-release-action@v2
-  #       with:
-  #         file: odbc2parquet-ubuntu-arm64.gz
-  #         asset_name: odbc2parquet-ubuntu-arm64.gz
-  #         tag: ${{ github.ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install latest rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+
+      - name: Install cross for cross-compilation
+        run: cargo install cross
+
+      - name: Cross-build for Ubuntu ARM (aarch64)
+        run: |
+          cross build --release --target aarch64-unknown-linux-gnu
+          gzip --force target/aarch64-unknown-linux-gnu/release/odbc2parquet
+          mv target/aarch64-unknown-linux-gnu/release/odbc2parquet.gz odbc2parquet-ubuntu-arm64.gz
+  
+      - name: Github Upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: odbc2parquet-ubuntu-arm64.gz
+          asset_name: odbc2parquet-ubuntu-arm64.gz
+          tag: ${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 # IDEs
 /.vscode/
 /.idea/
+
+# OSs
+.DS_Store

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,11 @@
+[target.aarch64-unknown-linux-gnu]
+# Disable `build-std` for `aarch64-unknown-linux-gnu`,
+# since it already has a std library pre-built.
+build-std = false
+# Install unixodbc:arm64 and unixodbc-dev:arm64, see <https://github.com/cross-rs/cross/blob/main/docs/custom_images.md#adding-dependencies-to-existing-images>
+# Additional commands to run prior to building the package.
+# These override the commands present in `[build]`: they will not merge.
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes unixodbc:$CROSS_DEB_ARCH unixodbc-dev:$CROSS_DEB_ARCH"
+]


### PR DESCRIPTION
This pull request addresses https://github.com/pacman82/odbc2parquet/issues/491.

- Use `dtolnay/rust-toolchain@v1` instead of the deprecated `actions-rs/toolchain@v1` to install Rust toolchains
- Correctly cross-build a Windows x86 executable
- Correctly cross-build an Ubuntu ARM64 artifact (using the Rust `cross` utility)