### PR TITLE
Use supported and up-to-date actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest rust toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Publish to cargo
         env:
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         run: |
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest rust toolchain
         uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Unix ODBC
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-          default: true
-          override: true
 
       - name: Install PostgreSQL Driver
         run: |

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## 6.0.7
 
-* Binary release for Ubuntu ARM architectures. Thanks @sindelevich
+* Binary release for Ubuntu ARM architectures. Thanks @sindilevich
 
 ## 6.0.2-6
 


### PR DESCRIPTION
This pull request addresses https://github.com/pacman82/odbc2parquet/issues/491.

- `actions-rs/toolchain` is an archived project, last updated 4 years ago
- `actions/checkout` is `v4` already; `v2` is giving a warning on an outdated node.js