### PR TITLE
chore: release v7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [7.0.2](https://github.com/pacman82/odbc2parquet/compare/v7.0.1...v7.0.2) - 2025-02-16
+
+### Other
+
+- fix linux tests
+- Update to odbc-api 11
+- *(deps)* bump clap from 4.5.28 to 4.5.29
+- *(deps)* bump bytesize from 1.3.0 to 1.3.2
+- *(deps)* bump clap from 4.5.27 to 4.5.28
+- *(deps)* bump bytes from 1.9.0 to 1.10.0
+- *(deps)* bump parquet from 54.0.0 to 54.1.0
+- *(deps)* bump clap_complete from 4.5.43 to 4.5.44
+- *(deps)* bump tempfile from 3.15.0 to 3.16.0
+- *(deps)* bump clap_complete from 4.5.42 to 4.5.43
+
 ## [7.0.1](https://github.com/pacman82/odbc2parquet/compare/v7.0.0...v7.0.1) - 2025-01-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "e034000e4c1f721449c69ef90489060116280e4114c360569f71eddb3021da09"
 
 [[package]]
 name = "odbc2parquet"
-version = "7.0.1"
+version = "7.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "7.0.1"
+version = "7.0.2"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 7.0.1 -> 7.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [7.0.2](https://github.com/pacman82/odbc2parquet/compare/v7.0.1...v7.0.2) - 2025-02-16

### Other

- fix linux tests
- Update to odbc-api 11
- *(deps)* bump clap from 4.5.28 to 4.5.29
- *(deps)* bump bytesize from 1.3.0 to 1.3.2
- *(deps)* bump clap from 4.5.27 to 4.5.28
- *(deps)* bump bytes from 1.9.0 to 1.10.0
- *(deps)* bump parquet from 54.0.0 to 54.1.0
- *(deps)* bump clap_complete from 4.5.43 to 4.5.44
- *(deps)* bump tempfile from 3.15.0 to 3.16.0
- *(deps)* bump clap_complete from 4.5.42 to 4.5.43
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).