### PR TITLE
chore: release v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [8.0.0](https://github.com/pacman82/odbc2parquet/compare/v7.0.4...v8.0.0) - 2025-04-17
+
+### Other
+
+- [**breaking**] Updated to newest parquet crate
+- *(deps)* bump assert_cmd from 2.0.16 to 2.0.17
+- *(deps)* bump clap from 4.5.35 to 4.5.36
+- *(deps)* bump anyhow from 1.0.97 to 1.0.98
+
 ## [7.0.4](https://github.com/pacman82/odbc2parquet/compare/v7.0.3...v7.0.4) - 2025-04-08
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Other
 
-- [**breaking**] Updated to newest parquet crate
+- [**breaking**] Updated to newest parquet crate. As a consequece valid compression level ranges using `--column-compression-level-default` have changed.
 - *(deps)* bump assert_cmd from 2.0.16 to 2.0.17
 - *(deps)* bump clap from 4.5.35 to 4.5.36
 - *(deps)* bump anyhow from 1.0.97 to 1.0.98

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ checksum = "e034000e4c1f721449c69ef90489060116280e4114c360569f71eddb3021da09"
 
 [[package]]
 name = "odbc2parquet"
-version = "7.0.4"
+version = "8.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "7.0.4"
+version = "8.0.0"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 7.0.4 -> 8.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.0.0](https://github.com/pacman82/odbc2parquet/compare/v7.0.4...v8.0.0) - 2025-04-17

### Other

- [**breaking**] Updated to newest parquet crate
- *(deps)* bump assert_cmd from 2.0.16 to 2.0.17
- *(deps)* bump clap from 4.5.35 to 4.5.36
- *(deps)* bump anyhow from 1.0.97 to 1.0.98
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).