### PR TITLE
chore: release v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,10 @@
 
 ### Added
 
-- Enable exec subcommand
+- The `exec` subcommand has been addded. It is a generalization of `insert` as it allows for passing the SQL statement on the command line. Named input placeholders are used to associate the statement parameters with columns in the input parquet file.
 
 ### Other
 
-- execute now reuses buffers in case of multiple mentions of the same placeholder
-- Introduce InputParameterMapping::parameter_to_buffer_index
-- Remove unused member from IndexMapping
-- IntroduceIndexMapping
 - *(deps)* bump odbc-api from 13.0.1 to 13.1.0
 
 ## [8.0.1](https://github.com/pacman82/odbc2parquet/compare/v8.0.0...v8.0.1) - 2025-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [8.1.0](https://github.com/pacman82/odbc2parquet/compare/v8.0.1...v8.1.0) - 2025-06-26
+
+### Added
+
+- Enable exec subcommand
+
+### Other
+
+- execute now reuses buffers in case of multiple mentions of the same placeholder
+- Introduce InputParameterMapping::parameter_to_buffer_index
+- Remove unused member from IndexMapping
+- IntroduceIndexMapping
+- *(deps)* bump odbc-api from 13.0.1 to 13.1.0
+
 ## [8.0.1](https://github.com/pacman82/odbc2parquet/compare/v8.0.0...v8.0.1) - 2025-06-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "e034000e4c1f721449c69ef90489060116280e4114c360569f71eddb3021da09"
 
 [[package]]
 name = "odbc2parquet"
-version = "8.0.1"
+version = "8.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "8.0.1"
+version = "8.1.0"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 8.0.1 -> 8.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.1.0](https://github.com/pacman82/odbc2parquet/compare/v8.0.1...v8.1.0) - 2025-06-26

### Added

- Enable exec subcommand

### Other

- execute now reuses buffers in case of multiple mentions of the same placeholder
- Introduce InputParameterMapping::parameter_to_buffer_index
- Remove unused member from IndexMapping
- IntroduceIndexMapping
- *(deps)* bump odbc-api from 13.0.1 to 13.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).