### PR TITLE
chore: release v8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [8.1.1](https://github.com/pacman82/odbc2parquet/compare/v8.1.0...v8.1.1) - 2025-07-20
+
+### Other
+
+- Statements are only prepared once for execute or insert subcommand.
+- Update some comments in code
+- *(deps)* bump clap from 4.5.40 to 4.5.41
+- *(deps)* bump clap_complete from 4.5.54 to 4.5.55
+- *(deps)* bump io-arg from 0.2.1 to 0.2.2
+- *(deps)* bump odbc-api from 14.0.0 to 14.0.2
+
 ## [8.1.0](https://github.com/pacman82/odbc2parquet/compare/v8.0.1...v8.1.0) - 2025-06-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "e034000e4c1f721449c69ef90489060116280e4114c360569f71eddb3021da09"
 
 [[package]]
 name = "odbc2parquet"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "8.1.0"
+version = "8.1.1"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 8.1.0 -> 8.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.1.1](https://github.com/pacman82/odbc2parquet/compare/v8.1.0...v8.1.1) - 2025-07-20

### Other

- Statements are only prepared once for execute or insert subcommand.
- Update some comments in code
- *(deps)* bump clap from 4.5.40 to 4.5.41
- *(deps)* bump clap_complete from 4.5.54 to 4.5.55
- *(deps)* bump io-arg from 0.2.1 to 0.2.2
- *(deps)* bump odbc-api from 14.0.0 to 14.0.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).