### PR TITLE
chore: release v8.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [8.1.2](https://github.com/pacman82/odbc2parquet/compare/v8.1.1...v8.1.2) - 2025-08-07
+
+### Other
+
+- Update to parquet 56
+- Remove dev container
+- *(deps)* bump clap from 4.5.42 to 4.5.43
+- *(deps)* bump odbc-api from 14.2.0 to 14.2.1
+- *(deps)* bump clap from 4.5.41 to 4.5.42
+- *(deps)* bump odbc-api from 14.1.0 to 14.2.0
+# Changelog
+
 ## [8.1.1](https://github.com/pacman82/odbc2parquet/compare/v8.1.0...v8.1.1) - 2025-07-20
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "e034000e4c1f721449c69ef90489060116280e4114c360569f71eddb3021da09"
 
 [[package]]
 name = "odbc2parquet"
-version = "8.1.1"
+version = "8.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "8.1.1"
+version = "8.1.2"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 8.1.1 -> 8.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.1.2](https://github.com/pacman82/odbc2parquet/compare/v8.1.1...v8.1.2) - 2025-08-07

### Other

- Update to parquet 56
- Remove dev container
- *(deps)* bump clap from 4.5.42 to 4.5.43
- *(deps)* bump odbc-api from 14.2.0 to 14.2.1
- *(deps)* bump clap from 4.5.41 to 4.5.42
- *(deps)* bump odbc-api from 14.1.0 to 14.2.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).