### PR TITLE
chore: release v8.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.3](https://github.com/pacman82/odbc2parquet/compare/v8.1.2...v8.1.3) - 2025-09-23
+
+### Other
+
+- change test expectation to reflect formatting changes in parquet-read cli tool
+- *(deps)* bump clap from 4.5.47 to 4.5.48
+- *(deps)* bump odbc-api from 19.0.0 to 19.0.1
+- *(deps)* bump anyhow from 1.0.99 to 1.0.100
+- *(deps)* bump clap_complete from 4.5.57 to 4.5.58
+- *(deps)* bump bytesize from 2.0.1 to 2.1.0
+- update to newest version of chrono
+- *(deps)* bump tempfile from 3.21.0 to 3.22.0
+- *(deps)* bump odbc-api from 17.0.0 to 19.0.0
+- *(deps)* bump log from 0.4.27 to 0.4.28
+- *(deps)* bump clap from 4.5.46 to 4.5.47
+- *(deps)* bump clap from 4.5.45 to 4.5.46
+- *(deps)* bump parquet from 56.0.0 to 56.1.0
+- *(deps)* bump tempfile from 3.20.0 to 3.21.0
+
 ## [8.1.2](https://github.com/pacman82/odbc2parquet/compare/v8.1.1...v8.1.2) - 2025-08-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "acb069b57ebbad5234fb7197af7ee0c40daceb3946a86fa8d3f7a38393bf2770"
 
 [[package]]
 name = "odbc2parquet"
-version = "8.1.2"
+version = "8.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "8.1.2"
+version = "8.1.3"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 8.1.2 -> 8.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.1.3](https://github.com/pacman82/odbc2parquet/compare/v8.1.2...v8.1.3) - 2025-09-23

### Other

- change test expectation to reflect formatting changes in parquet-read cli tool
- *(deps)* bump clap from 4.5.47 to 4.5.48
- *(deps)* bump odbc-api from 19.0.0 to 19.0.1
- *(deps)* bump anyhow from 1.0.99 to 1.0.100
- *(deps)* bump clap_complete from 4.5.57 to 4.5.58
- *(deps)* bump bytesize from 2.0.1 to 2.1.0
- update to newest version of chrono
- *(deps)* bump tempfile from 3.21.0 to 3.22.0
- *(deps)* bump odbc-api from 17.0.0 to 19.0.0
- *(deps)* bump log from 0.4.27 to 0.4.28
- *(deps)* bump clap from 4.5.46 to 4.5.47
- *(deps)* bump clap from 4.5.45 to 4.5.46
- *(deps)* bump parquet from 56.0.0 to 56.1.0
- *(deps)* bump tempfile from 3.20.0 to 3.21.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).