### PR TITLE
chore: release v8.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.4](https://github.com/pacman82/odbc2parquet/compare/v8.1.3...v8.1.4) - 2025-11-02
+
+### Other
+
+- Repalace `Command::cargo_bin` with `cargo_bin_cmd!`
+- replace lazy_static with Once
+- *(deps)* bump assert_cmd from 2.0.17 to 2.1.1
+- *(deps)* bump clap from 4.5.50 to 4.5.51
+- *(deps)* bump clap_complete from 4.5.59 to 4.5.60
+- Update to parquet 57
+
 ## [8.1.3](https://github.com/pacman82/odbc2parquet/compare/v8.1.2...v8.1.3) - 2025-09-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ checksum = "bd7e3c4b5b7bbd3e7bd01dc00cb4614f2445591cad1f6f18a7e16d7f98c392e9"
 
 [[package]]
 name = "odbc2parquet"
-version = "8.1.3"
+version = "8.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "8.1.3"
+version = "8.1.4"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 8.1.3 -> 8.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.1.4](https://github.com/pacman82/odbc2parquet/compare/v8.1.3...v8.1.4) - 2025-11-02

### Other

- Repalace `Command::cargo_bin` with `cargo_bin_cmd!`
- replace lazy_static with Once
- *(deps)* bump assert_cmd from 2.0.17 to 2.1.1
- *(deps)* bump clap from 4.5.50 to 4.5.51
- *(deps)* bump clap_complete from 4.5.59 to 4.5.60
- Update to parquet 57
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).