### PR TITLE
chore: release v8.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.6](https://github.com/pacman82/odbc2parquet/compare/v8.1.5...v8.1.6) - 2026-03-03
+
+### Performance
+
+- Use simd implementation of encoding-rs for utf8 to utf16 path
+- Use x86-64-v3 (AVX2, BMI, FMA — Haswell 2013+) for all x86-64
+
 ## [8.1.5](https://github.com/pacman82/odbc2parquet/compare/v8.1.4...v8.1.5) - 2025-11-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ checksum = "348f5e1d16a8aa07e9e76fc62f82bf44d94c099c0d291b4b4b7e10574447434c"
 
 [[package]]
 name = "odbc2parquet"
-version = "8.1.5"
+version = "8.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "8.1.5"
+version = "8.1.6"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 8.1.5 -> 8.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.1.6](https://github.com/pacman82/odbc2parquet/compare/v8.1.5...v8.1.6) - 2026-03-03

### Performance

- Use simd implementation of encoding-rs for utf8 to utf16 path
- Use x86-64-v3 (AVX2, BMI, FMA — Haswell 2013+) for all x86-64
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).