### PR TITLE
chore: release v8.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.7](https://github.com/pacman82/odbc2parquet/compare/v8.1.6...v8.1.7) - 2026-03-18
+
+### Documentation
+
+- Remove superfluous backtick from example in README
+
+### Fixes
+
+- Fix a panic which occurred on windows then querying text columns.
+
 ## [8.1.6](https://github.com/pacman82/odbc2parquet/compare/v8.1.5...v8.1.6) - 2026-03-03
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ checksum = "ea9f3ae4f9a232be79c302213d765e7c00936484fb1375f7edfcfa52fe446f14"
 
 [[package]]
 name = "odbc2parquet"
-version = "8.1.6"
+version = "8.1.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "8.1.6"
+version = "8.1.7"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 8.1.6 -> 8.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [8.1.7](https://github.com/pacman82/odbc2parquet/compare/v8.1.6...v8.1.7) - 2026-03-18

### Documentation

- Remove superfluous backtick from example in README

### Fixes

- Fix a panic which occurred on windows then querying text columns.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).