### PR TITLE
chore: release v11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- [**breaking**] Use structured logging
+- [**breaking**] Reworked log messages to be more terse and on point. Used structured logging.
 
 ## [10.1.0](https://github.com/pacman82/odbc2parquet/compare/v10.0.1...v10.1.0) - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0](https://github.com/pacman82/odbc2parquet/compare/v10.1.0...v11.0.0) - 2026-04-10
+
+### Features
+
+- [**breaking**] Use structured logging
+
 ## [10.1.0](https://github.com/pacman82/odbc2parquet/compare/v10.0.1...v10.1.0) - 2026-04-09
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,7 +1241,7 @@ checksum = "245cb4fe8236df4fd352ba96075d754233c6509d654d9f1c1482158b7d6c083d"
 
 [[package]]
 name = "odbc2parquet"
-version = "10.1.0"
+version = "11.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "10.1.0"
+version = "11.0.0"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 10.1.0 -> 11.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [11.0.0](https://github.com/pacman82/odbc2parquet/compare/v10.1.0...v11.0.0) - 2026-04-10

### Features

- [**breaking**] Use structured logging
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).