### PR TITLE
chore: release v11.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 `odbc2parquet` adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## [11.0.1](https://github.com/pacman82/odbc2parquet/compare/11.0.0...11.0.1) - 2026-06-13
+
+### 📚 Documentation
+
+- Change changelog format
+
 
 ## [11.0.0](https://github.com/pacman82/odbc2parquet/compare/v10.1.0...v11.0.0) - 2026-04-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ checksum = "245cb4fe8236df4fd352ba96075d754233c6509d654d9f1c1482158b7d6c083d"
 
 [[package]]
 name = "odbc2parquet"
-version = "11.0.0"
+version = "11.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odbc2parquet"
-version = "11.0.0"
+version = "11.0.1"
 authors = ["Markus Klein"]
 edition = "2021"
 repository = "https://github.com/pacman82/odbc2parquet"


### PR DESCRIPTION



## 🤖 New release

* `odbc2parquet`: 11.0.0 -> 11.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [11.0.1](https://github.com/pacman82/odbc2parquet/compare/11.0.0...11.0.1) - 2026-06-13

### 📚 Documentation

- Change changelog format
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).